### PR TITLE
Updates dependency from lodash-node 2.4.1 to lodash 3.0.0

### DIFF
--- a/ArraySchema.js
+++ b/ArraySchema.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var isObject = require('lodash-node/modern/objects/isObject');
+var isObject = require('lodash/lang/isObject');
 
 function ArraySchema(itemSchema) {
   if (!isObject(itemSchema)) {

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 var EntitySchema = require('./EntitySchema'),
     ArraySchema = require('./ArraySchema'),
-    isObject = require('lodash-node/modern/objects/isObject'),
-    isEqual = require('lodash-node/modern/objects/isEqual');
+    isObject = require('lodash/lang/isObject'),
+    isEqual = require('lodash/lang/isEqual');
 
 function visitObject(obj, schema, bag) {
   var normalized = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Normalizes JSON according to schema for Flux application",
   "main": "index.js",
   "repository": {
@@ -27,6 +27,6 @@
     "mocha": "^1.21.4"
   },
   "dependencies": {
-    "lodash-node": "^2.4.1"
+    "lodash": "^3.0.0"
   }
 }


### PR DESCRIPTION
[lodash-node seems to be deprecated](https://github.com/lodash/lodash-node). This pull request updates the dependency to use lodash 3.0.0 instead.