### PR TITLE
Include an implementation of isEqual and isObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,10 +388,6 @@ AppDispatcher.register((payload) => {
 });
 ```
 
-## Dependencies
-
-* `lodash` for `isObject` and `isEqual`
-
 ## Running Tests
 
 ```

--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
     "mocha": "^2.2.5",
     "rimraf": "^2.4.2",
     "webpack": "^1.10.5"
-  },
-  "dependencies": {
-    "lodash": "^3.10.0"
   }
 }

--- a/src/ArraySchema.js
+++ b/src/ArraySchema.js
@@ -1,4 +1,4 @@
-import isObject from 'lodash/lang/isObject';
+import { isObject } from './utils';
 
 export default class ArraySchema {
   constructor(itemSchema) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import EntitySchema from './EntitySchema';
 import ArraySchema from './ArraySchema';
-import isObject from 'lodash/lang/isObject';
-import isEqual from 'lodash/lang/isEqual';
+import { isObject, isEqual } from './utils';
 
 function defaultAssignEntity(normalized, key, entity) {
   normalized[key] = entity;

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,6 +16,7 @@ function baseIsEqual(value, other, references) {
   }
 
   if (isObject(value) && isObject(other)) {
+    let returnValue = false;
 
     if (value.constructor.name === 'Array' && other.constructor.name === 'Array') {
       if (value.length === other.length) {
@@ -23,19 +24,23 @@ function baseIsEqual(value, other, references) {
         for (let i = 0; i < value.length; i++) {
           equalSoFar = equalSoFar && baseIsEqual(value[i], other[i], references);
         }
-        return equalSoFar;
+        returnValue = equalSoFar;
       }
     } else {
       let valueKeys = Object.keys(value),
           otherKeys = Object.keys(other);
 
       if (baseIsEqual(valueKeys, otherKeys, [])) {
-        return valueKeys.reduce(function(memo, prop){
+        returnValue = valueKeys.reduce(function(memo, prop){
 
           return memo && baseIsEqual(value[prop], other[prop], references);
         }, true);
       }
     }
+    references.pop();
+    references.pop();
+
+    return returnValue;
   }
 
   return false;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,51 @@
+function baseIsEqual(value, other, references) {
+  let indexOfValue = references.indexOf(value),
+      indexOfOther = references.indexOf(other);
+
+  if (isObject(value) && indexOfValue === -1) {
+    references.push(value);
+  }
+  if (isObject(value) && indexOfOther === -1) {
+    references.push(other);
+  }
+
+  if (value === other) {
+    return true;
+  } else if (indexOfValue >= 0 || indexOfOther >= 0) {
+    return false;
+  }
+
+  if (isObject(value) && isObject(other)) {
+
+    if (value.constructor.name === 'Array' && other.constructor.name === 'Array') {
+      if (value.length === other.length) {
+        let equalSoFar = true;
+        for (let i = 0; i < value.length; i++) {
+          equalSoFar = equalSoFar && baseIsEqual(value[i], other[i], references);
+        }
+        return equalSoFar;
+      }
+    } else {
+      let valueKeys = Object.keys(value),
+          otherKeys = Object.keys(other);
+
+      if (baseIsEqual(valueKeys, otherKeys, [])) {
+        return valueKeys.reduce(function(memo, prop){
+
+          return memo && baseIsEqual(value[prop], other[prop], references);
+        }, true);
+      }
+    }
+  }
+
+  return false;
+}
+
+export function isObject(value) {
+  const type = typeof value;
+  return value && (type === 'object' || type === 'function');
+}
+
+export function isEqual(value, other) {
+  return baseIsEqual(value, other, []);
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -163,7 +163,7 @@ describe('isEqual', function() {
               'nested13_0': 130
             }
           ]
-        },
+        }
       }, other = {
         'nested1': {
           'nested13': [
@@ -172,10 +172,47 @@ describe('isEqual', function() {
               'nested13_0': 130
             }
           ]
-        },
+        }
       };
       value.nested1.nested14 = value;
       other.nested1.nested14 = value;
+      isEqual(value, other).should.equal(true);
+
+      let somethingNested = { nestedKey: 'isNested' };
+      somethingNested.self = somethingNested;
+      value = {
+        'nested1': {
+          'nested11': somethingNested,
+          'nested12': somethingNested,
+          'nested13': {
+            'nested131': somethingNested,
+            'nested132': somethingNested,
+            'nested133': [
+              somethingNested,
+              somethingNested,
+              {
+                'deep': somethingNested
+              }
+            ]
+          }
+        }
+      }, other = {
+        'nested1': {
+          'nested11': somethingNested,
+          'nested12': somethingNested,
+          'nested13': {
+            'nested131': somethingNested,
+            'nested132': somethingNested,
+            'nested133': [
+              somethingNested,
+              somethingNested,
+              {
+                'deep': somethingNested
+              }
+            ]
+          }
+        }
+      };
       isEqual(value, other).should.equal(true);
     });
 
@@ -201,6 +238,31 @@ describe('isEqual', function() {
       };
       value.nested1.nested14 = value;
       other.nested1.nested14 = other;
+      isEqual(value, other).should.equal(false);
+
+      let somethingNested = { nestedKey: 'isNested' };
+      somethingNested.self = somethingNested;
+      value = {
+        'nested1': {
+          'nested11': somethingNested,
+          'nested12': somethingNested,
+          'nested13': {
+            'nested131': somethingNested,
+            'nested132': somethingNested
+          }
+        }
+      }, other = {
+        'nested1': {
+          'nested11': somethingNested,
+          'nested12': somethingNested,
+          'nested13': {
+            'nested131': somethingNested,
+            'nested132': {
+              'nested1321': somethingNested
+            }
+          }
+        }
+      };
       isEqual(value, other).should.equal(false);
     });
   });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,207 @@
+'use strict';
+
+var should = require('chai').should(),
+    utils = require('../src/utils'),
+    isEqual = utils.isEqual;
+
+describe('isEqual', function() {
+  let value, other;
+
+  describe ('two numbers', function(){
+    it('returns true for equal numbers', function(){
+      isEqual(8, 8).should.equal(true);
+    });
+
+    it('returns false for different numbers', function(){
+      isEqual(8, 64).should.equal(false);
+    });
+  });
+
+  describe ('one number, one object', function(){
+    it('returns false', function(){
+      isEqual(8, {}).should.equal(false);
+      isEqual({}, 16).should.equal(false);
+    });
+  });
+
+  describe ('one function, one object', function(){
+    it('returns false', function(){
+      value = function(){};
+      other = { key: undefined };
+      isEqual(value, other).should.equal(false);
+    });
+  });
+
+  describe ('null and undefined', function(){
+    it('returns false', function(){
+      isEqual(null, undefined).should.equal(false);
+    });
+  });
+
+  describe('two object trees, one level deep', function(){
+    it('returns true for objects with the same key/value pairs', function(){
+      value = { one: 1 };
+      other = { one: 1 };
+      isEqual(value, other).should.equal(true);
+
+      value = { one: 1, fib: [0, 1, 1, 2, 3, 5, 8] };
+      other = { one: 1, fib: [0, 1, 1, 2, 3, 5, 8] };
+      isEqual(value, other).should.equal(true);
+
+      value = { one: null };
+      other = { one: null };
+      isEqual(value, other).should.equal(true);
+    });
+
+    it('returns false for objects with different key/value pairs', function(){
+      value = { one: 1 };
+      other = { two: 1 };
+      isEqual(value, other).should.equal(false);
+
+      value = { one: 1 };
+      other = { one: 1, two: 2 };
+      isEqual(value, other).should.equal(false);
+    });
+  });
+
+  describe('two object trees, nested levels', function(){
+    it('returns true for deeply equal objects', function(){
+      value = {
+        'nested1': {
+          'nested11': 'n',
+          'nested12': 12,
+          'nested13': [
+            '131',
+            '132',
+            {
+              'nested13_0': 130
+            }
+          ]
+        },
+        'nested2': {
+        }
+      }, other = {
+        'nested1': {
+          'nested11': 'n',
+          'nested12': 12,
+          'nested13': [
+            '131',
+            '132',
+            {
+              'nested13_0': 130
+            }
+          ]
+        },
+        'nested2': {
+        }
+      };
+      isEqual(value, other).should.equal(true);
+
+      value = {
+        'nested1': [
+          1,
+          1
+        ],
+        'nested2': [
+          {
+            'nested2_0': 1
+          }
+        ]
+      }, other = {
+        'nested1': [
+          1,
+          1
+        ],
+        'nested2': [
+          {
+            'nested2_0': 1
+          }
+        ]
+      };
+      isEqual(value, other).should.equal(true);
+    });
+
+    it('returns false for objects with the slightest difference', function(){
+      value = {
+        'nested1': {
+          'nested11': 'n',
+          'nested12': 12,
+          'nested13': [
+            '131',
+            '132',
+            {
+              'nested13_0': 130
+            }
+          ]
+        },
+        'nested2': {
+        }
+      }, other = {
+        'nested1': {
+          'nested11': 'n',
+          'nested12': 12,
+          'nested13': [
+            '131',
+            '132',
+            {
+              'nested13_0': 131
+            }
+          ]
+        },
+        'nested2': {
+        }
+      };
+      isEqual(value, other).should.equal(false);
+    });
+
+    it('returns true for objects with circular references', function(){
+      value = {
+        'nested1': {
+          'nested13': [
+            '131',
+            {
+              'nested13_0': 130
+            }
+          ]
+        },
+      }, other = {
+        'nested1': {
+          'nested13': [
+            '131',
+            {
+              'nested13_0': 130
+            }
+          ]
+        },
+      };
+      value.nested1.nested14 = value;
+      other.nested1.nested14 = value;
+      isEqual(value, other).should.equal(true);
+    });
+
+    it('detects circular references and returns false before falling in an infinite loop', function(){
+      value = {
+        'nested1': {
+          'nested13': [
+            '131',
+            {
+              'nested13_0': 130
+            }
+          ]
+        },
+      }, other = {
+        'nested1': {
+          'nested13': [
+            '131',
+            {
+              'nested13_0': 130
+            }
+          ]
+        },
+      };
+      value.nested1.nested14 = value;
+      other.nested1.nested14 = other;
+      isEqual(value, other).should.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
Minified version of lodash is 48.7 K, and the only functions needed in normalizr are `isEqual` and `isObject`. This patch removes that dependency.

`normalizr.min.js` size:

```
before: 8.7 K
after:  3.4 K
```

Please let me know what you think about this patch, any feedback is greatly appreciated :smile: 