### PR TITLE
Add ability to specify custom id attribute function

### DIFF
--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -4,16 +4,18 @@ export default class EntitySchema {
       throw new Error('A string non-empty key is required');
     }
 
-    this._idAttribute = options.idAttribute || 'id';
     this._key = key;
+
+    const idAttribute = options.idAttribute || 'id';
+    this._getId = typeof idAttribute === 'function' ? idAttribute : x => x[idAttribute];
   }
 
   getKey() {
     return this._key;
   }
 
-  getIdAttribute() {
-    return this._idAttribute;
+  getId(entity) {
+    return this._getId(entity);
   }
 
   define(nestedSchema) {

--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,7 @@ function mergeIntoEntity(entityA, entityB, entityKey) {
 
 function visitEntity(entity, entitySchema, bag, options) {
   const entityKey = entitySchema.getKey();
-  const idAttribute = entitySchema.getIdAttribute();
-  const id = entity[idAttribute];
+  const id = entitySchema.getId(entity);
 
   if (!bag[entityKey]) {
     bag[entityKey] = {};

--- a/test/index.js
+++ b/test/index.js
@@ -153,6 +153,49 @@ describe('normalizr', function () {
     });
   });
 
+  it('can normalize single entity with custom id attribute function', function () {
+    function makeSlug(article) {
+      var posted = article.posted,
+          title = article.title.toLowerCase().replace(' ', '-');
+
+      return [title, posted.year, posted.month, posted.day].join('-');
+    }
+
+    var article = new Schema('articles', { idAttribute: makeSlug }),
+        input;
+
+    input = {
+      id: 1,
+      title: 'Some Article',
+      isFavorite: false,
+      posted: {
+        day: 12,
+        month: 3,
+        year: 1983
+      }
+    };
+
+    Object.freeze(input);
+
+    normalize(input, article).should.eql({
+      result: 'some-article-1983-3-12',
+      entities: {
+        articles: {
+          'some-article-1983-3-12': {
+            id: 1,
+            title: 'Some Article',
+            isFavorite: false,
+            posted: {
+              day: 12,
+              month: 3,
+              year: 1983
+            }
+          }
+        }
+      }
+    });
+  });
+
   it('can normalize an array', function () {
     var article = new Schema('articles'),
         input;


### PR DESCRIPTION
Hello!

I have ran into a few cases where a server -- not controlled by me -- returns nested JSON where:
* there isn't a single key which can serve as an identifier slug
* or the slug is embedded further within the object
* or the key requires some simple preprocessing

This PR uses the existing API of normalizr, but extend the `idAttribute` option to accept arbitrary functions. An example use case is in the included test.