### PR TITLE
unionOf -- extend polymorphic unions to fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,52 @@ article.define({
 });
 ```
 
+### `unionOf(schemaMap, [options])`
+
+Describe a schema which is a union of multiple schemas.  This is useful if you need the polymorphic behavior provided by `arrayOf` or `valuesOf` but for non-collection fields.
+
+Use the required `schemaAttribute` option to specify which schema to use for each entity.
+
+```javascript
+const group = new Schema('groups');
+const user = new Schema('users');
+
+// a member can be either a user or a group
+const member = {
+  users: user,
+  groups: group
+};
+
+// You can specify the name of the attribute that determines the schema
+group.define({
+  owner: unionOf(member, { schemaAttribute: 'type' })
+});
+
+// Or you can specify a function to infer it
+function inferSchema(entity) { /* ... */ }
+group.define({
+  creator: unionOf(member, { schemaAttribute: inferSchema })
+});
+```
+
+A `unionOf` schema can also be combined with `arrayOf` and `valueOf` with the same behavior as each supplied with the `schemaAttribute` option.
+
+```javascript
+const group = new Schema('groups');
+const user = new Schema('users');
+
+const member = unionOf({
+  users: user,
+  groups: group
+}, { schemaAttribute: 'type' });
+
+group.define({
+  owner: member,
+  members: arrayOf(member),
+  relationships: valuesOf(member)
+});
+```
+
 ### `normalize(obj, schema, [options])`
 
 Normalizes object according to schema.  

--- a/src/IterableSchema.js
+++ b/src/IterableSchema.js
@@ -1,4 +1,5 @@
 import isObject from 'lodash/lang/isObject';
+import UnionSchema from './UnionSchema';
 
 export default class ArraySchema {
   constructor(itemSchema, options = {}) {
@@ -6,23 +7,15 @@ export default class ArraySchema {
       throw new Error('ArraySchema requires item schema to be an object.');
     }
 
-    this._itemSchema = itemSchema;
-
     if (options.schemaAttribute) {
       const schemaAttribute = options.schemaAttribute;
-      this._getSchema = typeof schemaAttribute === 'function' ? schemaAttribute : x => x[schemaAttribute];
+      this._itemSchema = new UnionSchema(itemSchema, { schemaAttribute })
+    } else {
+      this._itemSchema = itemSchema;
     }
   }
 
   getItemSchema() {
     return this._itemSchema;
-  }
-
-  isPolymorphicSchema() {
-    return !!this._getSchema;
-  }
-
-  getSchemaKey(item) {
-    return this._getSchema(item);
   }
 }

--- a/src/UnionSchema.js
+++ b/src/UnionSchema.js
@@ -1,0 +1,26 @@
+import isObject from 'lodash/lang/isObject';
+
+export default class UnionSchema {
+  constructor(itemSchema, options) {
+    if (!isObject(itemSchema)) {
+      throw new Error('UnionSchema requires item schema to be an object.');
+    }
+
+    if (!options || !options.schemaAttribute) {
+      throw new Error('UnionSchema requires schemaAttribute option.');
+    }
+
+    this._itemSchema = itemSchema;
+
+    const schemaAttribute = options.schemaAttribute;
+    this._getSchema = typeof schemaAttribute === 'function' ? schemaAttribute : x => x[schemaAttribute];
+  }
+
+  getItemSchema() {
+    return this._itemSchema;
+  }
+
+  getSchemaKey(item) {
+    return this._getSchema(item);
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -35,10 +35,8 @@ function polymorphicMapper(iterableSchema, itemSchema, bag, options) {
 }
 
 function visitIterable(obj, iterableSchema, bag, options) {
-  const isPolymorphicSchema = iterableSchema.isPolymorphicSchema();
   const itemSchema = iterableSchema.getItemSchema();
-  const itemMapper = isPolymorphicSchema ? polymorphicMapper : defaultMapper;
-  const curriedItemMapper = itemMapper(iterableSchema, itemSchema, bag, options);
+  const curriedItemMapper = defaultMapper(iterableSchema, itemSchema, bag, options);
 
   if (Array.isArray(obj)) {
     return obj.map(curriedItemMapper);

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import EntitySchema from './EntitySchema';
 import IterableSchema from './IterableSchema';
+import UnionSchema from './UnionSchema';
 import isObject from 'lodash/lang/isObject';
 import isEqual from 'lodash/lang/isEqual';
 import mapValues from 'lodash/object/mapValues';
@@ -46,6 +47,11 @@ function visitIterable(obj, iterableSchema, bag, options) {
   }
 }
 
+function visitUnion(obj, unionSchema, bag, options) {
+  const itemSchema = unionSchema.getItemSchema();
+
+  return polymorphicMapper(unionSchema, itemSchema, bag, options)(obj);
+}
 
 function defaultMergeIntoEntity(entityA, entityB, entityKey) {
   for (let key in entityB) {
@@ -95,6 +101,8 @@ function visit(obj, schema, bag, options) {
     return visitEntity(obj, schema, bag, options);
   } else if (schema instanceof IterableSchema) {
     return visitIterable(obj, schema, bag, options);
+  } else if (schema instanceof UnionSchema) {
+    return visitUnion(obj, schema, bag, options);
   } else {
     return visitObject(obj, schema, bag, options);
   }
@@ -106,6 +114,10 @@ export function arrayOf(schema, options) {
 
 export function valuesOf(schema, options) {
   return new IterableSchema(schema, options);
+}
+
+export function unionOf(schema, options) {
+  return new UnionSchema(schema, options);
 }
 
 export { EntitySchema as Schema };


### PR DESCRIPTION
For collection fields `arrayOf` and `valuesOf` both allow polymorphic schemas if you specify a `schemaAttribute` option.  I didn't see the ability to do this for a non-collection field.  The use case for this is if a field can also be polymorphic.

Mentioned in issue : https://github.com/gaearon/normalizr/issues/40

An example would be a `group` where the owner could be a `group` or a `user`.

```js
    var user = new Schema('users'),
        group = new Schema('groups'),
        owner = unionOf({
          users: user,
          groups: group
        }, { schemaAttribute: 'type' });

    group.define({
      owner: owner,
    });
```

This pull request adds the syntax `unionOf`.  It mimics the behavior found in `IterableSchema` but applies it in a non-iterable manner.

This could also pull the polymorphic logic out of `IterableSchema` by making `itemSchema` an instance of `UnionSchema` (the added type) if `schemaAttribute` is specified.

```js

arrayOf(unionOf({ groups: group, users: user}, { schemaAttribute: 'type' })) === arrayOf({ groups: group, users: user }, { schemaAttribute: 'type' })
```

This is my fist pull request so let me know if I'm doing this wrong!  Thanks :)