### PR TITLE
Remove .babelrc from NPM-Package to support RN > v0.16.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 test
+.babelrc


### PR DESCRIPTION
In order to use normalizr with **react-native**, the **.babelrc** shouldn't be in the NPM-Package.
A "files"-whitelist in package.json, like gaearon/react-redux#206, would also be possible.