### PR TITLE
add back idAttribute method

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,31 @@ article.define({
 });
 ```
 
+### `Schema.prototype.getKey()`
+
+Returns the key of the schema.
+
+```javascript
+const article = new Schema('articles');
+
+article.getKey();
+// articles
+```
+
+### `Schema.prototype.getIdAttribute()`
+
+Returns the idAttribute of the schema.
+
+```javascript
+const article = new Schema('articles');
+const slugArticle = new Schema('articles', { idAttribute: 'slug' });
+
+article.getIdAttribute();
+// id
+slugArticle.getIdAttribute();
+// slug
+```
+
 ### `arrayOf(schema, [options])`
 
 Describes an array of the schema passed as argument.

--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -8,6 +8,7 @@ export default class EntitySchema {
 
     const idAttribute = options.idAttribute || 'id';
     this._getId = typeof idAttribute === 'function' ? idAttribute : x => x[idAttribute];
+    this._idAttribute = idAttribute;
   }
 
   getKey() {
@@ -16,6 +17,10 @@ export default class EntitySchema {
 
   getId(entity) {
     return this._getId(entity);
+  }
+
+  getIdAttribute() {
+    return this._idAttribute;
   }
 
   define(nestedSchema) {

--- a/test/index.js
+++ b/test/index.js
@@ -209,6 +209,8 @@ describe('normalizr', function () {
 
     Object.freeze(input);
 
+    article.getIdAttribute().should.eql('slug');
+
     normalize(input, article).should.eql({
       result: 'some-article',
       entities: {

--- a/test/index.js
+++ b/test/index.js
@@ -67,6 +67,9 @@ describe('normalizr', function () {
 
     Object.freeze(input);
 
+    article.getIdAttribute().should.eql('id');
+    article.getKey().should.eql('articles');
+
     normalize(input, article).should.eql({
       result: 1,
       entities: {
@@ -210,6 +213,7 @@ describe('normalizr', function () {
     Object.freeze(input);
 
     article.getIdAttribute().should.eql('slug');
+    article.getKey().should.eql('articles');
 
     normalize(input, article).should.eql({
       result: 'some-article',


### PR DESCRIPTION
This adds back the `getIdAttribute()` method that existed in [`v1.0.0`](https://github.com/gaearon/normalizr/blob/f3294e732bdf92820acba89f3a70eb8d5316a976/src/EntitySchema.js#L15-L17).

This is helpful for me when using with a library like `redux-crud` where it also needs the `idAttribute` passed in as an option. With this change I can create my schema as usual, and then read the idAttribute and pass it directly to the `redux-crud` reducer for each entity.