### PR TITLE
Use Lodash v4 and shortened paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "webpack": "^1.10.5"
   },
   "dependencies": {
-    "lodash": "^3.10.0"
+    "lodash": "^4.0.0"
   }
 }

--- a/src/IterableSchema.js
+++ b/src/IterableSchema.js
@@ -1,4 +1,4 @@
-import isObject from 'lodash/lang/isObject';
+import isObject from 'lodash/isObject';
 
 export default class ArraySchema {
   constructor(itemSchema, options = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import EntitySchema from './EntitySchema';
 import IterableSchema from './IterableSchema';
-import isObject from 'lodash/lang/isObject';
-import isEqual from 'lodash/lang/isEqual';
-import mapValues from 'lodash/object/mapValues';
+import isObject from 'lodash/isObject';
+import isEqual from 'lodash/isEqual';
+import mapValues from 'lodash/mapValues';
 
 function defaultAssignEntity(normalized, key, entity) {
   normalized[key] = entity;

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var should = require('chai').should(),
-    isEqual = require('lodash/lang/isEqual'),
-    isObject = require('lodash/lang/isObject'),
-    merge = require('lodash/object/merge'),
+    isEqual = require('lodash/isEqual'),
+    isObject = require('lodash/isObject'),
+    merge = require('lodash/merge'),
     normalizr = require('../src'),
     normalize = normalizr.normalize,
     Schema = normalizr.Schema,


### PR DESCRIPTION
Pros:

* New! Shiny! Hot off the presses lodash v4.0.0
* Likely longer maintained
* Shorter require paths

Cons:

* Bundled size goes from ~4.3k min+gz to 5.6kgz. ¯\\\_(ツ)\_/¯
* Drops support for IE < 9, like upcoming React v0.15

Tests continue to pass. Thanks Dan!