### PR TITLE
Schema.define could return associated instance

### DIFF
--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -29,5 +29,6 @@ export default class EntitySchema {
         this[key] = nestedSchema[key];
       }
     }
+    return this;
   }
 }


### PR DESCRIPTION
Found myself expecting `Schema.define()` to return the Schema instance when doing:

```javascript
// In './Group.js'
import { arrayOf } from 'normalizr';
import User from './User';

export default new Schema('groups').define({
  users: arrayOf(User)
});
```

Thought it'd be a good idea if it did return it.