### PR TITLE
Edit Usage and normalize() examples to explain second parameter better

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,8 +433,19 @@ article.define({
 
 // ...
 
-const json = getArticleArray();
-const normalized = normalize(json, arrayOf(article));
+// Normalize one article object
+const json = { id: 1, author: ... };
+const normalized = normalize(json, article);
+
+// Normalize an array of article objects
+const arr = [{ id: 1, author: ... }, ...]
+const normalized = normalize(arr, arrayOf(article));
+
+// Normalize an array of article objects, referenced by an object key:
+const wrappedArr = { articles: [{ id: 1, author: ... }, ...] }
+const normalized = normalize(wrappedArr, {
+  articles: arrayOf(article)
+});
 ```
 
 ## Explanation by Example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # normalizr [![build status](https://img.shields.io/travis/gaearon/normalizr/master.svg?style=flat-square)](https://travis-ci.org/gaearon/normalizr) [![npm version](https://img.shields.io/npm/v/normalizr.svg?style=flat-square)](https://www.npmjs.com/package/normalizr) [![npm downloads](https://img.shields.io/npm/dm/normalizr.svg?style=flat-square)](https://www.npmjs.com/package/normalizr)
 
-Normalizes deeply nested JSON API responses according to a schema for [Flux](https://facebook.github.io/flux) and [Redux](http://rackt.github.io/redux) apps.
+Normalizes deeply nested JSON API responses according to a schema for [Flux](https://facebook.github.io/flux) and [Redux](http://rackt.github.io/redux) apps.  
 Kudos to Jing Chen for suggesting this approach.
 
 ## Installation
@@ -21,9 +21,9 @@ See **[redux/examples/real-world](https://github.com/rackt/redux/tree/master/exa
 
 ## The Problem
 
-* You have a JSON API that returns deeply nested objects;
+* You have a JSON API that returns deeply nested objects;  
 * You want to port your app to [Flux](https://github.com/facebook/flux) or [Redux](http://rackt.github.io/redux);
-* You noticed [it's hard](https://groups.google.com/forum/#!topic/reactjs/jbh50-GJxpg) for Stores (or Reducers) to consume data from nested API responses.
+* You noticed [it's hard](https://groups.google.com/forum/#!topic/reactjs/jbh50-GJxpg) for Stores (or Reducers) to consume data from nested API responses.  
 
 Normalizr takes JSON and a schema and **replaces nested entities with their IDs, gathering all entities in dictionaries**.
 
@@ -233,10 +233,10 @@ AppDispatcher.register((payload) => {
 
 ### `new Schema(key, [options])`
 
-Schema lets you define a type of entity returned by your API.
-This should correspond to model in your server code.
+Schema lets you define a type of entity returned by your API.  
+This should correspond to model in your server code.  
 
-The `key` parameter lets you specify the name of the dictionary for this kind of entity.
+The `key` parameter lets you specify the name of the dictionary for this kind of entity.  
 
 ```javascript
 const article = new Schema('articles');
@@ -251,7 +251,7 @@ const article = new Schema('articles', { idAttribute: generateSlug });
 
 ### `Schema.prototype.define(nestedSchema)`
 
-Lets you specify relationships between different entities.
+Lets you specify relationships between different entities.  
 
 ```javascript
 const article = new Schema('articles');
@@ -408,7 +408,7 @@ group.define({
 
 ### `normalize(obj, schema, [options])`
 
-Normalizes object according to schema.
+Normalizes object according to schema.  
 Passed `schema` should be a nested object reflecting the structure of API response.
 
 You may optionally specify any of the following options:
@@ -467,7 +467,7 @@ collection: {
 }
 ```
 
-Without normalizr, your Stores would need to know too much about API response schema.
+Without normalizr, your Stores would need to know too much about API response schema.  
 For example, `UserStore` would include a lot of boilerplate to extract fresh user info when articles are fetched:
 
 ```javascript
@@ -553,7 +553,7 @@ AppDispatcher.register((payload) => {
 
 ## Browser Support
 
-Modern browsers with ES5 environments are supported.
+Modern browsers with ES5 environments are supported.  
 The minimal supported IE version is IE 9.
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ First, define a schema for our entities:
 ```javascript
 const article = new Schema('articles');
 const user = new Schema('users');
-const collection = new Schema('collections');
 ```
 
 Then we define nesting rules:
@@ -103,11 +102,6 @@ Then we define nesting rules:
 ```javascript
 article.define({
   author: user,
-  collections: arrayOf(collection)
-});
-
-collection.define({
-  curator: user
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # normalizr [![build status](https://img.shields.io/travis/gaearon/normalizr/master.svg?style=flat-square)](https://travis-ci.org/gaearon/normalizr) [![npm version](https://img.shields.io/npm/v/normalizr.svg?style=flat-square)](https://www.npmjs.com/package/normalizr) [![npm downloads](https://img.shields.io/npm/dm/normalizr.svg?style=flat-square)](https://www.npmjs.com/package/normalizr)
 
-Normalizes deeply nested JSON API responses according to a schema for [Flux](https://facebook.github.io/flux) and [Redux](http://rackt.github.io/redux) apps.  
+Normalizes deeply nested JSON API responses according to a schema for [Flux](https://facebook.github.io/flux) and [Redux](http://rackt.github.io/redux) apps.
 Kudos to Jing Chen for suggesting this approach.
 
 ## Installation
@@ -21,9 +21,9 @@ See **[redux/examples/real-world](https://github.com/rackt/redux/tree/master/exa
 
 ## The Problem
 
-* You have a JSON API that returns deeply nested objects;  
+* You have a JSON API that returns deeply nested objects;
 * You want to port your app to [Flux](https://github.com/facebook/flux) or [Redux](http://rackt.github.io/redux);
-* You noticed [it's hard](https://groups.google.com/forum/#!topic/reactjs/jbh50-GJxpg) for Stores (or Reducers) to consume data from nested API responses.  
+* You noticed [it's hard](https://groups.google.com/forum/#!topic/reactjs/jbh50-GJxpg) for Stores (or Reducers) to consume data from nested API responses.
 
 Normalizr takes JSON and a schema and **replaces nested entities with their IDs, gathering all entities in dictionaries**.
 
@@ -118,7 +118,7 @@ const ServerActionCreators = {
     // Passing { articles: arrayOf(article) } as second parameter to normalize()
     // lets it correctly traverse the response tree and gather all entities:
     
-    // BEFORE
+    // BEFORE:
     // {
     //   articles: [{
     //     id: 1,
@@ -165,7 +165,7 @@ const ServerActionCreators = {
     // Passing { users: arrayOf(user) } as second parameter to normalize()
     // lets it correctly traverse the response tree and gather all entities:
     
-    // BEFORE
+    // BEFORE:
     // {
     //   users: [{
     //     id: 7,
@@ -185,7 +185,7 @@ const ServerActionCreators = {
     //       ..
     //     }
     //   }
-    
+    // }
 
     response = normalize(response, {
       users: arrayOf(user)
@@ -217,10 +217,10 @@ AppDispatcher.register((payload) => {
 
 ### `new Schema(key, [options])`
 
-Schema lets you define a type of entity returned by your API.  
-This should correspond to model in your server code.  
+Schema lets you define a type of entity returned by your API.
+This should correspond to model in your server code.
 
-The `key` parameter lets you specify the name of the dictionary for this kind of entity.  
+The `key` parameter lets you specify the name of the dictionary for this kind of entity.
 
 ```javascript
 const article = new Schema('articles');
@@ -235,7 +235,7 @@ const article = new Schema('articles', { idAttribute: generateSlug });
 
 ### `Schema.prototype.define(nestedSchema)`
 
-Lets you specify relationships between different entities.  
+Lets you specify relationships between different entities.
 
 ```javascript
 const article = new Schema('articles');
@@ -392,7 +392,7 @@ group.define({
 
 ### `normalize(obj, schema, [options])`
 
-Normalizes object according to schema.  
+Normalizes object according to schema.
 Passed `schema` should be a nested object reflecting the structure of API response.
 
 You may optionally specify any of the following options:
@@ -440,7 +440,7 @@ collection: {
 }
 ```
 
-Without normalizr, your Stores would need to know too much about API response schema.  
+Without normalizr, your Stores would need to know too much about API response schema.
 For example, `UserStore` would include a lot of boilerplate to extract fresh user info when articles are fetched:
 
 ```javascript
@@ -526,7 +526,7 @@ AppDispatcher.register((payload) => {
 
 ## Browser Support
 
-Modern browsers with ES5 environments are supported.  
+Modern browsers with ES5 environments are supported.
 The minimal supported IE version is IE 9.
 
 ## Running Tests


### PR DESCRIPTION
This concerns improving the Usage example to better show how the second parameter for normalize() is used. 

Currently, the example in the Usage section has these two normalize calls, which handle responses with similar structure:
```
response = normalize(response, {
  articles: arrayOf(article)
});

response = normalize(response, {
  users: arrayOf(user)
});
```
The example could be more informative, if it showed how to normalize two different response object structures, like this:
```
// response is just one article object
response = normalize(response, article);

// response is an object with a reference to an array of article objects
response = normalize(response, {
  articles: arrayOf(article)
});
```
In addition to revising the Usage example, I suggest adding these examples to the normalize() specification.

It took me a while to figure out why my normalized data did not look as expected, and while I am new to the field, maybe someone else could also be saved some time by this, without making the README significantly longer.

Thanks for your great work and please let me know if there is something I should fix to make this a proper improvement.