### PR TITLE
Remove unnecessary Array.isArray() checks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,11 +120,11 @@ export function unionOf(schema, options) {
 export { EntitySchema as Schema };
 
 export function normalize(obj, schema, options = {}) {
-  if (!isObject(obj) && !Array.isArray(obj)) {
+  if (!isObject(obj)) {
     throw new Error('Normalize accepts an object or an array as its input.');
   }
 
-  if (!isObject(schema) || Array.isArray(schema)) {
+  if (!isObject(schema)) {
     throw new Error('Normalize accepts an object for schema.');
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ export function normalize(obj, schema, options = {}) {
     throw new Error('Normalize accepts an object or an array as its input.');
   }
 
-  if (!isObject(schema)) {
+  if (!isObject(schema) || Array.isArray(schema)) {
     throw new Error('Normalize accepts an object for schema.');
   }
 


### PR DESCRIPTION
The Array.isArray() checks included in the normalize function were not needed since lodash's isObject() already checks for valid arrays
```
_.isObject(value)
Checks if value is the language type of Object. 
(e.g. arrays, functions, objects, regexes, new Number(0), and new String(''))
```
[Source] (https://devdocs.io/lodash~4/index#isObject)