### PR TITLE
Give assignEntity access to the original input object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ function visitObject(obj, schema, bag, options) {
   for (let key in obj) {
     if (obj.hasOwnProperty(key)) {
       const entity = visit(obj[key], schema[key], bag, options);
-      assignEntity.call(null, normalized, key, entity);
+      assignEntity.call(null, normalized, key, entity, obj);
     }
   }
   return normalized;


### PR DESCRIPTION
## Problem

When using `assignEntity`, we need to build values based on information from multiple keys/entities in the original input to `normalize`. 

Why do this here? When reading from a state happens more often than writing, it's much better to have this done once on receipt than every time it's accessed.

## Solution

Change `assignEntity` to be given a fourth argument, the value of the original, non-normalized object.

Resolves #64